### PR TITLE
Fix: Early return statement

### DIFF
--- a/components/Buttons.tsx
+++ b/components/Buttons.tsx
@@ -120,6 +120,12 @@ export function PDFButton({ resumeSlug }: PDFButtonProps) {
         toast.error('You must be a premium member to download PDFs.');
     }
 
+    useEffect(() => {
+        setTimeout(() => {
+            setLoading(false);
+        }, 1500)
+    }, [])
+
     if (!isPremium) {
         return (
             <Button style={{
@@ -134,12 +140,6 @@ export function PDFButton({ resumeSlug }: PDFButtonProps) {
             </Button>
         )
     }
-
-    useEffect(() => {
-        setTimeout(() => {
-            setLoading(false);
-        }, 1500)
-    }, [])
 
     if (loading) {
         return <Loader />


### PR DESCRIPTION
Error was preventing the resume screen from loading the PDF button properly, causing the entire screen to crash.